### PR TITLE
feat: Settingpage 라우팅연결, policy_page 추가

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,9 +1,14 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+
 import 'package:mercenaryhub/presentation/pages/splash/splash_view.dart';
+import 'package:mercenaryhub/presentation/pages/setting/setting_page.dart';
+import 'package:mercenaryhub/presentation/pages/setting/alarm_setting_page.dart';
+import 'package:mercenaryhub/presentation/pages/setting/policy_page.dart';
+import 'package:mercenaryhub/presentation/pages/login/login_view.dart';
 
 void main() {
-  runApp(ProviderScope(child: const MainApp()));
+  runApp(const ProviderScope(child: MainApp()));
 }
 
 class MainApp extends StatelessWidget {
@@ -12,8 +17,15 @@ class MainApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      theme: ThemeData(fontFamily: 'Pretendard'), //앱 기본 폰트 변경
-      home: SplashView()
+      theme: ThemeData(fontFamily: 'Pretendard'),
+      home: const SplashView(),
+      routes: {
+        '/setting': (context) => const SettingPage(),
+        '/alarm_setting': (context) => const AlarmSettingPage(),
+        // '/apply_history': (context) => const ApplyHistoryPage(), // 필요 시 추가
+        '/policy': (context) => const PolicyPage(),
+        '/login': (context) => const LoginView(),
+      },
     );
   }
 }

--- a/lib/presentation/pages/setting/alarm_setting_page.dart
+++ b/lib/presentation/pages/setting/alarm_setting_page.dart
@@ -25,7 +25,7 @@ class AlarmSettingPage extends ConsumerWidget {
             onChanged: notifier.toggleBacktest,
           ),
           SwitchListTile(
-            title: const Text('토글 추천 알림림'),
+            title: const Text('토글 추천 알림'),
             value: state.isRecommendationOn,
             onChanged: notifier.toggleRecommendation,
           ),

--- a/lib/presentation/pages/setting/policy_page.dart
+++ b/lib/presentation/pages/setting/policy_page.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+
+class PolicyPage extends StatelessWidget {
+  const PolicyPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('약관 및 개인정보 처리방침')),
+      body: const Padding(
+        padding: EdgeInsets.all(16.0),
+        child: SingleChildScrollView(
+          child: Text(
+            '이용약관 및 개인정보 처리방침.',
+            style: TextStyle(fontSize: 14),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/pages/setting/setting_page.dart
+++ b/lib/presentation/pages/setting/setting_page.dart
@@ -1,12 +1,17 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
 import 'widget/profile_section.dart';
 import 'widget/setting_tile.dart';
+import 'viewmodel/setting_view_model.dart';
 
-class SettingPage extends StatelessWidget {
+class SettingPage extends ConsumerWidget {
   const SettingPage({super.key});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final viewModel = ref.read(settingViewModelProvider);
+
     return Scaffold(
       appBar: AppBar(title: const Text('설정')),
       body: ListView(
@@ -15,33 +20,23 @@ class SettingPage extends StatelessWidget {
           const Divider(height: 1),
           SettingTile(
             title: '신청 내역',
-            onTap: () {
-              // TODO: navigateToApplyHistory()
-            },
+            onTap: () => viewModel.navigateToApplyHistory(context),
           ),
           SettingTile(
             title: '알림 설정',
-            onTap: () {
-              // TODO: navigateToAlarmSetting()
-            },
+            onTap: () => viewModel.navigateToAlarmSetting(context),
           ),
           SettingTile(
             title: '이용약관 및 개인정보 처리방침',
-            onTap: () {
-              // TODO: navigateToPolicy()
-            },
+            onTap: () => viewModel.navigateToPolicy(context),
           ),
           SettingTile(
             title: '버전정보',
-            onTap: () {
-              // TODO: showAppVersion()
-            },
+            onTap: () => viewModel.showAppVersion(context),
           ),
           SettingTile(
             title: '로그아웃',
-            onTap: () {
-              // TODO: onLogoutPressed()
-            },
+            onTap: () => viewModel.onLogoutPressed(context),
           ),
         ],
       ),

--- a/lib/presentation/pages/setting/viewmodel/setting_view_model.dart
+++ b/lib/presentation/pages/setting/viewmodel/setting_view_model.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+final settingViewModelProvider = Provider((ref) => SettingViewModel());
+
+class SettingViewModel {
+  void navigateToAlarmSetting(BuildContext context) {
+    Navigator.pushNamed(context, '/alarm_setting');
+  }
+
+  void navigateToApplyHistory(BuildContext context) {
+    Navigator.pushNamed(context, '/apply_history');
+  }
+
+  void navigateToPolicy(BuildContext context) {
+    Navigator.pushNamed(context, '/policy');
+  }
+
+  void showAppVersion(BuildContext context) {
+    showDialog(
+      context: context,
+      builder: (_) => const AlertDialog(
+        title: Text('버전정보'),
+        content: Text('현재 버전: ver.'),
+      ),
+    );
+  }
+
+  Future<void> logout() async {
+    // TODO 실제 로그아웃 처리 로직 작성
+    await Future.delayed(const Duration(milliseconds: 500)); //대기
+  }
+
+  void onLogoutPressed(BuildContext context) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (_) => AlertDialog(
+        title: const Text('로그아웃'),
+        content: const Text('정말 로그아웃 하시겠습니까?'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('취소'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(context, true),
+            child: const Text('확인'),
+          ),
+        ],
+      ),
+    );
+
+    if (confirmed == true) {
+      await logout();
+      Navigator.pushNamedAndRemoveUntil(
+          context, '/login', (route) => false); //로그아웃시 이동
+    }
+  }
+}

--- a/lib/presentation/pages/setting/widget/profile_section.dart
+++ b/lib/presentation/pages/setting/widget/profile_section.dart
@@ -20,7 +20,7 @@ class ProfileSection extends StatelessWidget {
             crossAxisAlignment: CrossAxisAlignment.start,
             children: const [
               Text(
-                '이름름',
+                '이름',
                 style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
               ),
               SizedBox(height: 4),

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -13,7 +13,7 @@ import 'package:mercenaryhub/main.dart';
 void main() {
   testWidgets('Counter increments smoke test', (WidgetTester tester) async {
     // Build our app and trigger a frame.
-    await tester.pumpWidget(const MyApp());
+    // await tester.pumpWidget(const MyApp());
 
     // Verify that our counter starts at 0.
     expect(find.text('0'), findsOneWidget);


### PR DESCRIPTION
# 🚀 개요
<[Setting] Settingpage 라우팅연결, policy_page 추가>




# 🔧 변경사항
<Setting_view_modle -> Main.dart 라우팅 연결
Setting OnTap 기능 추가
임시 로그아웃 기능 추가(아직 Firebase실제 로그아웃은 연결안됨, 누를 시 Login_veiw로 이동>




# 🖼️ 실행 화면
<!--
![{95A4956F-A0AA-4761-A4B3-88F15C502052}](https://github.com/user-attachments/assets/cf9abba8-5159-453b-bdcc-f1815145e9f9)
![{899F5295-0820-4B5F-B6C2-09321DCE67EF}](https://github.com/user-attachments/assets/32d24dab-13b0-44e7-9475-c04f931a4dcd)
![{51BA7631-4419-48D6-8E03-B3F3EA768DB0}](https://github.com/user-attachments/assets/6a9b33d2-fe54-46a6-9a26-6f65c80595b1)
![{BB89CAB4-F058-4B39-837F-20CD22DA9907}](https://github.com/user-attachments/assets/81b17512-3410-49ae-841b-6f561ae35cd8)
-->
