### PR TITLE
[Setting] 신청내역 페이지 추가(더미데이터 추가), 카카오 이메일 삭제 Fixes#38

### DIFF
--- a/lib/data/data_source/mercenary_apply_history_data_source.dart
+++ b/lib/data/data_source/mercenary_apply_history_data_source.dart
@@ -1,0 +1,14 @@
+import 'package:mercenaryhub/data/dto/mercenary_apply_history_dto.dart';
+
+abstract interface class MercenaryApplyHistoryDataSource {
+  /// 용병이 팀에 신청한 내역 조회
+  Future<List<MercenaryApplyHistoryDto>> fetchMercenaryApplyHistories(
+      String userId);
+
+  /// 신청 취소
+  Future<bool> cancelApply(String applyHistoryId);
+
+  /// 특정 신청 내역 조회
+  Future<MercenaryApplyHistoryDto?> fetchMercenaryApplyHistoryById(
+      String applyHistoryId);
+}

--- a/lib/data/data_source/mercenary_apply_history_data_source_impl.dart
+++ b/lib/data/data_source/mercenary_apply_history_data_source_impl.dart
@@ -1,0 +1,72 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:mercenaryhub/data/data_source/mercenary_apply_history_data_source.dart';
+import 'package:mercenaryhub/data/dto/mercenary_apply_history_dto.dart';
+
+class MercenaryApplyHistoryDataSourceImpl
+    implements MercenaryApplyHistoryDataSource {
+  final FirebaseFirestore _firebaseFirestore;
+
+  MercenaryApplyHistoryDataSourceImpl(this._firebaseFirestore);
+
+  @override
+  Future<List<MercenaryApplyHistoryDto>> fetchMercenaryApplyHistories(
+      String userId) async {
+    try {
+      final querySnapshot = await _firebaseFirestore
+          .collection('mercenaryApplyHistories')
+          .where('userId', isEqualTo: userId)
+          .orderBy('appliedAt', descending: true)
+          .get();
+
+      return querySnapshot.docs.map((doc) {
+        final data = doc.data();
+        return MercenaryApplyHistoryDto.fromJson({
+          'id': doc.id,
+          ...data,
+        });
+      }).toList();
+    } catch (e) {
+      print('fetchMercenaryApplyHistories error: $e');
+      return [];
+    }
+  }
+
+  @override
+  Future<bool> cancelApply(String applyHistoryId) async {
+    try {
+      await _firebaseFirestore
+          .collection('mercenaryApplyHistories')
+          .doc(applyHistoryId)
+          .update({
+        'status': 'cancelled',
+        'cancelledAt': DateTime.now().toIso8601String(),
+      });
+      return true;
+    } catch (e) {
+      print('cancelApply error: $e');
+      return false;
+    }
+  }
+
+  @override
+  Future<MercenaryApplyHistoryDto?> fetchMercenaryApplyHistoryById(
+      String applyHistoryId) async {
+    try {
+      final doc = await _firebaseFirestore
+          .collection('mercenaryApplyHistories')
+          .doc(applyHistoryId)
+          .get();
+
+      if (doc.exists) {
+        return MercenaryApplyHistoryDto.fromJson({
+          'id': doc.id,
+          ...doc.data()!,
+        });
+      }
+      return null;
+    } catch (e) {
+      print('fetchMercenaryApplyHistoryById error: $e');
+      return null;
+    }
+  }
+}

--- a/lib/data/data_source/team_apply_history_data_source.dart
+++ b/lib/data/data_source/team_apply_history_data_source.dart
@@ -1,0 +1,15 @@
+import 'package:mercenaryhub/data/dto/team_apply_history_dto.dart';
+
+abstract interface class TeamApplyHistoryDataSource {
+  /// 팀이 용병에게 신청한 내역 조회
+  Future<List<TeamApplyHistoryDto>> fetchTeamApplyHistories(String teamId);
+
+  /// 신청 상태 업데이트
+  Future<bool> updateApplyStatus({
+    required String applyHistoryId,
+    required String status,
+  });
+
+  /// 특정 신청 내역 조회
+  Future<TeamApplyHistoryDto?> fetchTeamApplyHistoryById(String applyHistoryId);
+}

--- a/lib/data/data_source/team_apply_history_data_source_impl.dart
+++ b/lib/data/data_source/team_apply_history_data_source_impl.dart
@@ -1,0 +1,74 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:mercenaryhub/data/data_source/team_apply_history_data_source.dart';
+import 'package:mercenaryhub/data/dto/team_apply_history_dto.dart';
+
+class TeamApplyHistoryDataSourceImpl implements TeamApplyHistoryDataSource {
+  final FirebaseFirestore _firebaseFirestore;
+
+  TeamApplyHistoryDataSourceImpl(this._firebaseFirestore);
+
+  @override
+  Future<List<TeamApplyHistoryDto>> fetchTeamApplyHistories(
+      String teamId) async {
+    try {
+      final querySnapshot = await _firebaseFirestore
+          .collection('teamApplyHistories')
+          .where('teamId', isEqualTo: teamId)
+          .orderBy('appliedAt', descending: true)
+          .get();
+
+      return querySnapshot.docs.map((doc) {
+        final data = doc.data();
+        return TeamApplyHistoryDto.fromJson({
+          'id': doc.id,
+          ...data,
+        });
+      }).toList();
+    } catch (e) {
+      print('fetchTeamApplyHistories error: $e');
+      return [];
+    }
+  }
+
+  @override
+  Future<bool> updateApplyStatus({
+    required String applyHistoryId,
+    required String status,
+  }) async {
+    try {
+      await _firebaseFirestore
+          .collection('teamApplyHistories')
+          .doc(applyHistoryId)
+          .update({
+        'status': status,
+        'updatedAt': DateTime.now().toIso8601String(),
+      });
+      return true;
+    } catch (e) {
+      print('updateApplyStatus error: $e');
+      return false;
+    }
+  }
+
+  @override
+  Future<TeamApplyHistoryDto?> fetchTeamApplyHistoryById(
+      String applyHistoryId) async {
+    try {
+      final doc = await _firebaseFirestore
+          .collection('teamApplyHistories')
+          .doc(applyHistoryId)
+          .get();
+
+      if (doc.exists) {
+        return TeamApplyHistoryDto.fromJson({
+          'id': doc.id,
+          ...doc.data()!,
+        });
+      }
+      return null;
+    } catch (e) {
+      print('fetchTeamApplyHistoryById error: $e');
+      return null;
+    }
+  }
+}

--- a/lib/data/dto/mercenary_apply_history_dto.dart
+++ b/lib/data/dto/mercenary_apply_history_dto.dart
@@ -1,0 +1,67 @@
+class MercenaryApplyHistoryDto {
+  final String id;
+  final String userId;
+  final String teamId;
+  final String teamName;
+  final String teamProfileImage;
+  final String feedId;
+  final String appliedAt;
+  final String status;
+  final String location;
+  final String gameDate;
+  final String gameTime;
+  final String cost;
+  final String level;
+
+  MercenaryApplyHistoryDto({
+    required this.id,
+    required this.userId,
+    required this.teamId,
+    required this.teamName,
+    required this.teamProfileImage,
+    required this.feedId,
+    required this.appliedAt,
+    required this.status,
+    required this.location,
+    required this.gameDate,
+    required this.gameTime,
+    required this.cost,
+    required this.level,
+  });
+
+  factory MercenaryApplyHistoryDto.fromJson(Map<String, dynamic> json) {
+    return MercenaryApplyHistoryDto(
+      id: json['id'],
+      userId: json['userId'],
+      teamId: json['teamId'],
+      teamName: json['teamName'],
+      teamProfileImage: json['teamProfileImage'] ?? '',
+      feedId: json['feedId'],
+      appliedAt: json['appliedAt'],
+      status: json['status'],
+      location: json['location'],
+      gameDate: json['gameDate'],
+      gameTime: json['gameTime'],
+      cost: json['cost'],
+      level: json['level'],
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'userId': userId,
+      'teamId': teamId,
+      'teamName': teamName,
+      'teamProfileImage': teamProfileImage,
+      'feedId': feedId,
+      'appliedAt': appliedAt,
+      'status': status,
+      'location': location,
+      'gameDate': gameDate,
+      'gameTime': gameTime,
+      'cost': cost,
+      'level': level,
+    };
+  }
+}

--- a/lib/data/dto/team_apply_history_dto.dart
+++ b/lib/data/dto/team_apply_history_dto.dart
@@ -1,0 +1,63 @@
+class TeamApplyHistoryDto {
+  final String id;
+  final String teamName;
+  final String mercenaryUserId;
+  final String mercenaryName;
+  final String mercenaryProfileImage;
+  final String feedId;
+  final String appliedAt;
+  final String status;
+  final String location;
+  final String gameDate;
+  final String gameTime;
+  final String level;
+
+  TeamApplyHistoryDto({
+    required this.id,
+    required this.teamName,
+    required this.mercenaryUserId,
+    required this.mercenaryName,
+    required this.mercenaryProfileImage,
+    required this.feedId,
+    required this.appliedAt,
+    required this.status,
+    required this.location,
+    required this.gameDate,
+    required this.gameTime,
+    required this.level,
+  });
+
+  factory TeamApplyHistoryDto.fromJson(Map<String, dynamic> json) {
+    return TeamApplyHistoryDto(
+      id: json['id'],
+      teamName: json['teamName'],
+      mercenaryUserId: json['mercenaryUserId'],
+      mercenaryName: json['mercenaryName'],
+      mercenaryProfileImage: json['mercenaryProfileImage'] ?? '',
+      feedId: json['feedId'],
+      appliedAt: json['appliedAt'],
+      status: json['status'],
+      location: json['location'],
+      gameDate: json['gameDate'],
+      gameTime: json['gameTime'],
+      level: json['level'],
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'teamName': teamName,
+      'mercenaryUserId': mercenaryUserId,
+      'mercenaryName': mercenaryName,
+      'mercenaryProfileImage': mercenaryProfileImage,
+      'feedId': feedId,
+      'appliedAt': appliedAt,
+      'status': status,
+      'location': location,
+      'gameDate': gameDate,
+      'gameTime': gameTime,
+      'level': level,
+    };
+  }
+}

--- a/lib/data/repository/mercenary_apply_history_repository_impl.dart
+++ b/lib/data/repository/mercenary_apply_history_repository_impl.dart
@@ -1,0 +1,64 @@
+import 'package:mercenaryhub/data/data_source/mercenary_apply_history_data_source.dart';
+import 'package:mercenaryhub/domain/entity/mercenary_apply_history.dart';
+import 'package:mercenaryhub/domain/repository/mercenary_apply_history_repository.dart';
+
+class MercenaryApplyHistoryRepositoryImpl
+    implements MercenaryApplyHistoryRepository {
+  final MercenaryApplyHistoryDataSource _dataSource;
+
+  MercenaryApplyHistoryRepositoryImpl(this._dataSource);
+
+  @override
+  Future<List<MercenaryApplyHistory>> fetchMercenaryApplyHistories(
+      String userId) async {
+    final dtoList = await _dataSource.fetchMercenaryApplyHistories(userId);
+
+    return dtoList.map((dto) {
+      return MercenaryApplyHistory(
+        id: dto.id,
+        userId: dto.userId,
+        teamId: dto.teamId,
+        teamName: dto.teamName,
+        teamProfileImage: dto.teamProfileImage,
+        feedId: dto.feedId,
+        appliedAt: DateTime.parse(dto.appliedAt),
+        status: dto.status,
+        location: dto.location,
+        gameDate: DateTime.parse(dto.gameDate),
+        gameTime: dto.gameTime,
+        cost: dto.cost,
+        level: dto.level,
+      );
+    }).toList();
+  }
+
+  @override
+  Future<bool> cancelApply(String applyHistoryId) async {
+    return await _dataSource.cancelApply(applyHistoryId);
+  }
+
+  @override
+  Future<MercenaryApplyHistory?> fetchMercenaryApplyHistoryById(
+      String applyHistoryId) async {
+    final dto =
+        await _dataSource.fetchMercenaryApplyHistoryById(applyHistoryId);
+
+    if (dto == null) return null;
+
+    return MercenaryApplyHistory(
+      id: dto.id,
+      userId: dto.userId,
+      teamId: dto.teamId,
+      teamName: dto.teamName,
+      teamProfileImage: dto.teamProfileImage,
+      feedId: dto.feedId,
+      appliedAt: DateTime.parse(dto.appliedAt),
+      status: dto.status,
+      location: dto.location,
+      gameDate: DateTime.parse(dto.gameDate),
+      gameTime: dto.gameTime,
+      cost: dto.cost,
+      level: dto.level,
+    );
+  }
+}

--- a/lib/data/repository/team_apply_history_repository_impl.dart
+++ b/lib/data/repository/team_apply_history_repository_impl.dart
@@ -1,0 +1,65 @@
+import 'package:mercenaryhub/data/data_source/team_apply_history_data_source.dart';
+import 'package:mercenaryhub/domain/entity/team_apply_history.dart';
+import 'package:mercenaryhub/domain/repository/team_apply_history_repository.dart';
+
+class TeamApplyHistoryRepositoryImpl implements TeamApplyHistoryRepository {
+  final TeamApplyHistoryDataSource _dataSource;
+
+  TeamApplyHistoryRepositoryImpl(this._dataSource);
+
+  @override
+  Future<List<TeamApplyHistory>> fetchTeamApplyHistories(String teamId) async {
+    final dtoList = await _dataSource.fetchTeamApplyHistories(teamId);
+
+    return dtoList.map((dto) {
+      return TeamApplyHistory(
+        id: dto.id,
+        teamName: dto.teamName,
+        mercenaryUserId: dto.mercenaryUserId,
+        mercenaryName: dto.mercenaryName,
+        mercenaryProfileImage: dto.mercenaryProfileImage,
+        feedId: dto.feedId,
+        appliedAt: DateTime.parse(dto.appliedAt),
+        status: dto.status,
+        location: dto.location,
+        gameDate: DateTime.parse(dto.gameDate),
+        gameTime: dto.gameTime,
+        level: dto.level,
+      );
+    }).toList();
+  }
+
+  @override
+  Future<bool> updateApplyStatus({
+    required String applyHistoryId,
+    required String status,
+  }) async {
+    return await _dataSource.updateApplyStatus(
+      applyHistoryId: applyHistoryId,
+      status: status,
+    );
+  }
+
+  @override
+  Future<TeamApplyHistory?> fetchTeamApplyHistoryById(
+      String applyHistoryId) async {
+    final dto = await _dataSource.fetchTeamApplyHistoryById(applyHistoryId);
+
+    if (dto == null) return null;
+
+    return TeamApplyHistory(
+      id: dto.id,
+      teamName: dto.teamName,
+      mercenaryUserId: dto.mercenaryUserId,
+      mercenaryName: dto.mercenaryName,
+      mercenaryProfileImage: dto.mercenaryProfileImage,
+      feedId: dto.feedId,
+      appliedAt: DateTime.parse(dto.appliedAt),
+      status: dto.status,
+      location: dto.location,
+      gameDate: DateTime.parse(dto.gameDate),
+      gameTime: dto.gameTime,
+      level: dto.level,
+    );
+  }
+}

--- a/lib/domain/entity/mercenary_apply_history.dart
+++ b/lib/domain/entity/mercenary_apply_history.dart
@@ -1,0 +1,31 @@
+class MercenaryApplyHistory {
+  final String id;
+  final String userId; // 용병 유저 ID
+  final String teamId;
+  final String teamName;
+  final String teamProfileImage;
+  final String feedId;
+  final DateTime appliedAt;
+  final String status; // pending, accepted, rejected
+  final String location;
+  final DateTime gameDate;
+  final String gameTime;
+  final String cost;
+  final String level;
+
+  MercenaryApplyHistory({
+    required this.id,
+    required this.userId,
+    required this.teamId,
+    required this.teamName,
+    required this.teamProfileImage,
+    required this.feedId,
+    required this.appliedAt,
+    required this.status,
+    required this.location,
+    required this.gameDate,
+    required this.gameTime,
+    required this.cost,
+    required this.level,
+  });
+}

--- a/lib/domain/entity/team_apply_history.dart
+++ b/lib/domain/entity/team_apply_history.dart
@@ -1,0 +1,29 @@
+class TeamApplyHistory {
+  final String id;
+  final String teamName;
+  final String mercenaryUserId;
+  final String mercenaryName;
+  final String mercenaryProfileImage;
+  final String feedId;
+  final DateTime appliedAt;
+  final String status; // pending, accepted, rejected
+  final String location;
+  final DateTime gameDate;
+  final String gameTime;
+  final String level;
+
+  TeamApplyHistory({
+    required this.id,
+    required this.teamName,
+    required this.mercenaryUserId,
+    required this.mercenaryName,
+    required this.mercenaryProfileImage,
+    required this.feedId,
+    required this.appliedAt,
+    required this.status,
+    required this.location,
+    required this.gameDate,
+    required this.gameTime,
+    required this.level,
+  });
+}

--- a/lib/domain/repository/mercenary_apply_history_repository.dart
+++ b/lib/domain/repository/mercenary_apply_history_repository.dart
@@ -1,0 +1,14 @@
+import 'package:mercenaryhub/domain/entity/mercenary_apply_history.dart';
+
+abstract interface class MercenaryApplyHistoryRepository {
+  /// 용병이 팀에 신청한 내역 조회
+  Future<List<MercenaryApplyHistory>> fetchMercenaryApplyHistories(
+      String userId);
+
+  /// 신청 취소
+  Future<bool> cancelApply(String applyHistoryId);
+
+  /// 특정 신청 내역 상세 조회
+  Future<MercenaryApplyHistory?> fetchMercenaryApplyHistoryById(
+      String applyHistoryId);
+}

--- a/lib/domain/repository/team_apply_history_repository.dart
+++ b/lib/domain/repository/team_apply_history_repository.dart
@@ -1,0 +1,15 @@
+import 'package:mercenaryhub/domain/entity/team_apply_history.dart';
+
+abstract interface class TeamApplyHistoryRepository {
+  /// 팀이 용병에게 신청한 내역 조회
+  Future<List<TeamApplyHistory>> fetchTeamApplyHistories(String teamId);
+
+  /// 신청 상태 업데이트 (승인/거절)
+  Future<bool> updateApplyStatus({
+    required String applyHistoryId,
+    required String status,
+  });
+
+  /// 특정 신청 내역 상세 조회
+  Future<TeamApplyHistory?> fetchTeamApplyHistoryById(String applyHistoryId);
+}

--- a/lib/domain/usecase/cancel_mercenary_apply_usecase.dart
+++ b/lib/domain/usecase/cancel_mercenary_apply_usecase.dart
@@ -1,0 +1,13 @@
+// domain/usecase/cancel_mercenary_apply_usecase.dart
+
+import 'package:mercenaryhub/domain/repository/mercenary_apply_history_repository.dart';
+
+class CancelMercenaryApplyUsecase {
+  final MercenaryApplyHistoryRepository _repository;
+
+  CancelMercenaryApplyUsecase(this._repository);
+
+  Future<bool> execute(String applyHistoryId) async {
+    return await _repository.cancelApply(applyHistoryId);
+  }
+}

--- a/lib/domain/usecase/fetch_mercenary_apply_histories_usecase.dart
+++ b/lib/domain/usecase/fetch_mercenary_apply_histories_usecase.dart
@@ -1,0 +1,14 @@
+// domain/usecase/fetch_mercenary_apply_histories_usecase.dart
+
+import 'package:mercenaryhub/domain/entity/mercenary_apply_history.dart';
+import 'package:mercenaryhub/domain/repository/mercenary_apply_history_repository.dart';
+
+class FetchMercenaryApplyHistoriesUsecase {
+  final MercenaryApplyHistoryRepository _repository;
+
+  FetchMercenaryApplyHistoriesUsecase(this._repository);
+
+  Future<List<MercenaryApplyHistory>> execute(String userId) async {
+    return await _repository.fetchMercenaryApplyHistories(userId);
+  }
+}

--- a/lib/domain/usecase/fetch_team_apply_histories_usecase.dart
+++ b/lib/domain/usecase/fetch_team_apply_histories_usecase.dart
@@ -1,0 +1,12 @@
+import 'package:mercenaryhub/domain/entity/team_apply_history.dart';
+import 'package:mercenaryhub/domain/repository/team_apply_history_repository.dart';
+
+class FetchTeamApplyHistoriesUsecase {
+  final TeamApplyHistoryRepository _repository;
+
+  FetchTeamApplyHistoriesUsecase(this._repository);
+
+  Future<List<TeamApplyHistory>> execute(String teamId) async {
+    return await _repository.fetchTeamApplyHistories(teamId);
+  }
+}

--- a/lib/domain/usecase/update_team_apply_status_usecase.dart
+++ b/lib/domain/usecase/update_team_apply_status_usecase.dart
@@ -1,0 +1,17 @@
+import 'package:mercenaryhub/domain/repository/team_apply_history_repository.dart';
+
+class UpdateTeamApplyStatusUsecase {
+  final TeamApplyHistoryRepository _repository;
+
+  UpdateTeamApplyStatusUsecase(this._repository);
+
+  Future<bool> execute({
+    required String applyHistoryId,
+    required String status,
+  }) async {
+    return await _repository.updateApplyStatus(
+      applyHistoryId: applyHistoryId,
+      status: status,
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -12,6 +12,8 @@ import 'package:mercenaryhub/presentation/pages/home/home_page.dart';
 import 'package:mercenaryhub/presentation/pages/splash/splash_view.dart';
 import 'package:mercenaryhub/presentation/pages/setting/setting_page.dart';
 import 'package:mercenaryhub/presentation/pages/setting/alarm_setting_page.dart';
+import 'package:mercenaryhub/presentation/pages/team_apply_history/team_apply_history_page.dart';
+import 'package:mercenaryhub/presentation/pages/mercenary_apply_history/mercenary_apply_history_page.dart';
 import 'package:mercenaryhub/presentation/pages/login/login_view.dart';
 import 'package:mercenaryhub/presentation/pages/terms/widget/terms_page.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -41,6 +43,9 @@ class MainApp extends StatelessWidget {
       routes: {
         '/setting': (context) => const SettingPage(),
         '/alarm_setting': (context) => const AlarmSettingPage(),
+        '/team_apply_history': (context) => const TeamApplyHistoryPage(),
+        '/mercenary_apply_history': (context) =>
+            const MercenaryApplyHistoryPage(),
         '/terms': (context) => const TermsOfServiceAgreement(),
         '/home': (context) => const HomePage(),
         '/login': (context) => const LoginView(),

--- a/lib/presentation/pages/mercenary_apply_history/mercenary_apply_history_item.dart
+++ b/lib/presentation/pages/mercenary_apply_history/mercenary_apply_history_item.dart
@@ -1,0 +1,191 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:mercenaryhub/domain/entity/mercenary_apply_history.dart';
+
+class MercenaryApplyHistoryItem extends StatelessWidget {
+  final MercenaryApplyHistory history;
+  final VoidCallback onCancel;
+
+  const MercenaryApplyHistoryItem({
+    super.key,
+    required this.history,
+    required this.onCancel,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: Colors.grey[300]!),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withOpacity(0.05),
+            blurRadius: 4,
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              CircleAvatar(
+                radius: 24,
+                backgroundColor: Colors.grey[300],
+                backgroundImage: history.teamProfileImage.isNotEmpty
+                    ? NetworkImage(history.teamProfileImage)
+                    : null,
+                child: history.teamProfileImage.isEmpty
+                    ? const Icon(Icons.groups, color: Colors.grey)
+                    : null,
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      history.teamName,
+                      style: const TextStyle(
+                        fontSize: 16,
+                        fontWeight: FontWeight.bold,
+                        color: Color(0xFF222222),
+                      ),
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      '신청일: ${DateFormat('yyyy.MM.dd').format(history.appliedAt)}',
+                      style: TextStyle(
+                        fontSize: 14,
+                        color: Colors.grey[600],
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              _buildStatusChip(history.status),
+            ],
+          ),
+          const SizedBox(height: 16),
+          Container(
+            padding: const EdgeInsets.all(12),
+            decoration: BoxDecoration(
+              color: Colors.grey[50],
+              borderRadius: BorderRadius.circular(8),
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                _buildInfoRow(Icons.location_on, history.location),
+                const SizedBox(height: 8),
+                _buildInfoRow(
+                  Icons.calendar_today,
+                  DateFormat('yyyy년 MM월 dd일').format(history.gameDate),
+                ),
+                const SizedBox(height: 8),
+                _buildInfoRow(Icons.access_time, history.gameTime),
+                const SizedBox(height: 8),
+                _buildInfoRow(Icons.military_tech, history.level),
+                const SizedBox(height: 8),
+                _buildInfoRow(
+                  Icons.attach_money,
+                  '${NumberFormat('#,###').format(int.parse(history.cost))}원',
+                ),
+              ],
+            ),
+          ),
+          if (history.status == 'pending') ...[
+            const SizedBox(height: 16),
+            SizedBox(
+              width: double.infinity,
+              child: OutlinedButton(
+                onPressed: onCancel,
+                style: OutlinedButton.styleFrom(
+                  foregroundColor: Colors.red,
+                  side: const BorderSide(color: Colors.red),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                ),
+                child: const Text('신청 취소'),
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  Widget _buildStatusChip(String status) {
+    Color backgroundColor;
+    Color textColor;
+    String text;
+
+    switch (status) {
+      case 'pending':
+        backgroundColor = Colors.orange[100]!;
+        textColor = Colors.orange[800]!;
+        text = '대기중';
+        break;
+      case 'accepted':
+        backgroundColor = Colors.green[100]!;
+        textColor = Colors.green[800]!;
+        text = '수락됨';
+        break;
+      case 'rejected':
+        backgroundColor = Colors.red[100]!;
+        textColor = Colors.red[800]!;
+        text = '거절됨';
+        break;
+      case 'cancelled':
+        backgroundColor = Colors.grey[300]!;
+        textColor = Colors.grey[700]!;
+        text = '취소됨';
+        break;
+      default:
+        backgroundColor = Colors.grey[100]!;
+        textColor = Colors.grey[800]!;
+        text = '알 수 없음';
+    }
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+      decoration: BoxDecoration(
+        color: backgroundColor,
+        borderRadius: BorderRadius.circular(16),
+      ),
+      child: Text(
+        text,
+        style: TextStyle(
+          fontSize: 12,
+          fontWeight: FontWeight.bold,
+          color: textColor,
+        ),
+      ),
+    );
+  }
+
+  Widget _buildInfoRow(IconData icon, String text) {
+    return Row(
+      children: [
+        Icon(
+          icon,
+          size: 16,
+          color: Colors.grey[600],
+        ),
+        const SizedBox(width: 8),
+        Text(
+          text,
+          style: TextStyle(
+            fontSize: 14,
+            color: Colors.grey[800],
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/presentation/pages/mercenary_apply_history/mercenary_apply_history_page.dart
+++ b/lib/presentation/pages/mercenary_apply_history/mercenary_apply_history_page.dart
@@ -1,0 +1,114 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:mercenaryhub/presentation/pages/mercenary_apply_history/mercenary_apply_history_item.dart';
+import 'package:mercenaryhub/presentation/pages/mercenary_apply_history/mercenary_apply_history_view_model.dart';
+
+class MercenaryApplyHistoryPage extends ConsumerWidget {
+  const MercenaryApplyHistoryPage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final state = ref.watch(mercenaryApplyHistoryViewModelProvider);
+
+    return Scaffold(
+      backgroundColor: const Color(0xFFFFFFFF),
+      appBar: AppBar(
+        backgroundColor: const Color(0xFFFFFFFF),
+        foregroundColor: const Color(0xFF222222),
+        elevation: 0,
+        title: const Text('용병 신청내역'),
+        shape: Border(
+          bottom: BorderSide(
+            color: Colors.grey[300]!,
+          ),
+        ),
+      ),
+      body: state.when(
+        data: (histories) {
+          if (histories.isEmpty) {
+            return Center(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Icon(
+                    Icons.inbox_outlined,
+                    size: 64,
+                    color: Colors.grey[400],
+                  ),
+                  const SizedBox(height: 16),
+                  Text(
+                    '신청내역이 없습니다',
+                    style: TextStyle(
+                      fontSize: 16,
+                      color: Colors.grey[600],
+                    ),
+                  ),
+                ],
+              ),
+            );
+          }
+
+          return RefreshIndicator(
+            onRefresh: () async {
+              ref.invalidate(mercenaryApplyHistoryViewModelProvider);
+            },
+            color: const Color(0xFF2BBB7D),
+            child: ListView.separated(
+              padding: const EdgeInsets.all(16),
+              itemCount: histories.length,
+              separatorBuilder: (context, index) => const SizedBox(height: 12),
+              itemBuilder: (context, index) {
+                return MercenaryApplyHistoryItem(
+                  history: histories[index],
+                  onCancel: () {
+                    ref
+                        .read(mercenaryApplyHistoryViewModelProvider.notifier)
+                        .cancelApply(histories[index].id);
+                  },
+                );
+              },
+            ),
+          );
+        },
+        loading: () => const Center(
+          child: CircularProgressIndicator(
+            color: Color(0xFF2BBB7D),
+          ),
+        ),
+        error: (error, stack) => Center(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              const Icon(
+                Icons.error_outline,
+                size: 64,
+                color: Colors.red,
+              ),
+              const SizedBox(height: 16),
+              const Text(
+                '오류가 발생했습니다',
+                style: TextStyle(
+                  fontSize: 16,
+                  color: Color(0xFF222222),
+                ),
+              ),
+              const SizedBox(height: 8),
+              ElevatedButton(
+                onPressed: () {
+                  ref.invalidate(mercenaryApplyHistoryViewModelProvider);
+                },
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: const Color(0xFF2BBB7D),
+                ),
+                child: const Text(
+                  '다시 시도',
+                  style: TextStyle(color: Colors.white),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/pages/mercenary_apply_history/mercenary_apply_history_view_model.dart
+++ b/lib/presentation/pages/mercenary_apply_history/mercenary_apply_history_view_model.dart
@@ -1,0 +1,72 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:mercenaryhub/domain/entity/mercenary_apply_history.dart';
+import 'package:mercenaryhub/presentation/pages/providers.dart';
+
+class MercenaryApplyHistoryViewModel
+    extends AsyncNotifier<List<MercenaryApplyHistory>> {
+  @override
+  Future<List<MercenaryApplyHistory>> build() async {
+    return await fetchMercenaryApplyHistories();
+  }
+
+  Future<List<MercenaryApplyHistory>> fetchMercenaryApplyHistories() async {
+    await Future.delayed(const Duration(milliseconds: 500)); // 로딩 시뮬레이션
+
+    return [
+      MercenaryApplyHistory(
+        id: 'dummy-apply-1',
+        userId: 'mercenary123',
+        teamId: 'team456',
+        teamName: 'FC 용병모집단',
+        teamProfileImage: 'https://via.placeholder.com/150',
+        feedId: 'feed789',
+        appliedAt: DateTime.now().subtract(const Duration(days: 1)),
+        status: 'pending',
+        location: '서울 송파구',
+        gameDate: DateTime.now().add(const Duration(days: 2)),
+        gameTime: '19:30',
+        cost: '30000',
+        level: '중급',
+      ),
+    ];
+  }
+
+  // Future<List<MercenaryApplyHistory>> fetchMercenaryApplyHistories() async {
+  //   final fetchUsecase = ref.read(fetchMercenaryApplyHistoriesUsecaseProvider);
+
+  //   final user = FirebaseAuth.instance.currentUser;
+  //   if (user == null) {
+  //     throw Exception('로그인이 필요합니다');
+  //   }
+
+  //   return await fetchUsecase.execute(user.uid);
+  // }
+
+  Future<void> cancelApply(String applyHistoryId) async {
+    final cancelUsecase = ref.read(cancelMercenaryApplyUsecaseProvider);
+
+    state = const AsyncValue.loading();
+
+    try {
+      final success = await cancelUsecase.execute(applyHistoryId);
+
+      if (success) {
+        // 취소 후 목록 새로고침
+        state = await AsyncValue.guard(() => fetchMercenaryApplyHistories());
+      } else {
+        state = AsyncValue.error(
+          '신청 취소에 실패했습니다',
+          StackTrace.current,
+        );
+      }
+    } catch (e, stack) {
+      state = AsyncValue.error(e, stack);
+    }
+  }
+}
+
+final mercenaryApplyHistoryViewModelProvider = AsyncNotifierProvider<
+    MercenaryApplyHistoryViewModel, List<MercenaryApplyHistory>>(
+  () => MercenaryApplyHistoryViewModel(),
+);

--- a/lib/presentation/pages/providers.dart
+++ b/lib/presentation/pages/providers.dart
@@ -7,12 +7,20 @@ import 'package:mercenaryhub/data/data_source/feed_log_data_source.dart';
 import 'package:mercenaryhub/data/data_source/feed_log_data_source_impl.dart';
 import 'package:mercenaryhub/data/data_source/location_data_source.dart';
 import 'package:mercenaryhub/data/data_source/location_data_source_impl.dart';
+import 'package:mercenaryhub/data/data_source/team_apply_history_data_source.dart';
+import 'package:mercenaryhub/data/data_source/team_apply_history_data_source_impl.dart';
+import 'package:mercenaryhub/data/data_source/mercenary_apply_history_data_source.dart';
+import 'package:mercenaryhub/data/data_source/mercenary_apply_history_data_source_impl.dart';
 import 'package:mercenaryhub/data/repository/feed_log_repository_impl.dart';
 import 'package:mercenaryhub/data/repository/feed_repository_impl.dart';
 import 'package:mercenaryhub/data/repository/location_repository_impl.dart';
+import 'package:mercenaryhub/data/repository/team_apply_history_repository_impl.dart';
+import 'package:mercenaryhub/data/repository/mercenary_apply_history_repository_impl.dart';
 import 'package:mercenaryhub/domain/repository/feed_log_repository.dart';
 import 'package:mercenaryhub/domain/repository/feed_repository.dart';
 import 'package:mercenaryhub/domain/repository/location_repository.dart';
+import 'package:mercenaryhub/domain/repository/team_apply_history_repository.dart';
+import 'package:mercenaryhub/domain/repository/mercenary_apply_history_repository.dart';
 import 'package:mercenaryhub/domain/usecase/fetch_feed_logs_usecase.dart';
 import 'package:mercenaryhub/domain/usecase/fetch_feeds_usecase.dart';
 import 'package:firebase_storage/firebase_storage.dart';
@@ -25,6 +33,10 @@ import 'package:mercenaryhub/domain/usecase/insert_feed_log_usecase.dart';
 import 'package:mercenaryhub/domain/usecase/insert_feed_usecase.dart';
 import 'package:mercenaryhub/domain/usecase/stream_fetch_feeds_usecase.dart';
 import 'package:mercenaryhub/domain/usecase/upload_image_usecase.dart';
+import 'package:mercenaryhub/domain/usecase/fetch_team_apply_histories_usecase.dart';
+import 'package:mercenaryhub/domain/usecase/update_team_apply_status_usecase.dart';
+import 'package:mercenaryhub/domain/usecase/fetch_mercenary_apply_histories_usecase.dart';
+import 'package:mercenaryhub/domain/usecase/cancel_mercenary_apply_usecase.dart';
 
 final _feedDataSourceProvider = Provider<FeedDataSource>((ref) {
   return FeedDataSourceImpl(FirebaseFirestore.instance);
@@ -97,4 +109,48 @@ final _locationRepository = Provider<LocationRepository>((ref) {
 final getLocationUsecaseProvider = Provider((ref) {
   final repository = ref.read(_locationRepository);
   return GetLocationUsecase(repository);
+});
+
+// Team Apply History Providers
+final _teamApplyHistoryDataSourceProvider =
+    Provider<TeamApplyHistoryDataSource>((ref) {
+  return TeamApplyHistoryDataSourceImpl(FirebaseFirestore.instance);
+});
+
+final _teamApplyHistoryRepositoryProvider =
+    Provider<TeamApplyHistoryRepository>((ref) {
+  final dataSource = ref.read(_teamApplyHistoryDataSourceProvider);
+  return TeamApplyHistoryRepositoryImpl(dataSource);
+});
+
+final fetchTeamApplyHistoriesUsecaseProvider = Provider((ref) {
+  final repository = ref.read(_teamApplyHistoryRepositoryProvider);
+  return FetchTeamApplyHistoriesUsecase(repository);
+});
+
+final updateTeamApplyStatusUsecaseProvider = Provider((ref) {
+  final repository = ref.read(_teamApplyHistoryRepositoryProvider);
+  return UpdateTeamApplyStatusUsecase(repository);
+});
+
+// Mercenary Apply History Providers
+final _mercenaryApplyHistoryDataSourceProvider =
+    Provider<MercenaryApplyHistoryDataSource>((ref) {
+  return MercenaryApplyHistoryDataSourceImpl(FirebaseFirestore.instance);
+});
+
+final _mercenaryApplyHistoryRepositoryProvider =
+    Provider<MercenaryApplyHistoryRepository>((ref) {
+  final dataSource = ref.read(_mercenaryApplyHistoryDataSourceProvider);
+  return MercenaryApplyHistoryRepositoryImpl(dataSource);
+});
+
+final fetchMercenaryApplyHistoriesUsecaseProvider = Provider((ref) {
+  final repository = ref.read(_mercenaryApplyHistoryRepositoryProvider);
+  return FetchMercenaryApplyHistoriesUsecase(repository);
+});
+
+final cancelMercenaryApplyUsecaseProvider = Provider((ref) {
+  final repository = ref.read(_mercenaryApplyHistoryRepositoryProvider);
+  return CancelMercenaryApplyUsecase(repository);
 });

--- a/lib/presentation/pages/setting/alarm_setting_page.dart
+++ b/lib/presentation/pages/setting/alarm_setting_page.dart
@@ -23,7 +23,7 @@ class AlarmSettingPage extends ConsumerWidget {
           SwitchListTile(
             tileColor: const Color(0xFFFFFFFF),
             title: const Text(
-              '시그널 알림',
+              '전체 알림',
               style: TextStyle(
                 color: Color(0xFF222222),
                 fontSize: 16,
@@ -36,7 +36,20 @@ class AlarmSettingPage extends ConsumerWidget {
           SwitchListTile(
             tileColor: const Color(0xFFFFFFFF),
             title: const Text(
-              '백테스팅 알림',
+              '푸시 알림',
+              style: TextStyle(
+                color: Color(0xFF222222),
+                fontSize: 16,
+              ),
+            ),
+            value: state.isSignalOn,
+            onChanged: notifier.toggleSignal,
+            activeColor: const Color(0xFF2BBB7D),
+          ),
+          SwitchListTile(
+            tileColor: const Color(0xFFFFFFFF),
+            title: const Text(
+              '용병신청 알림',
               style: TextStyle(
                 color: Color(0xFF222222),
                 fontSize: 16,
@@ -49,7 +62,7 @@ class AlarmSettingPage extends ConsumerWidget {
           SwitchListTile(
             tileColor: const Color(0xFFFFFFFF),
             title: const Text(
-              '토글 추천 알림',
+              '신청승인 알림',
               style: TextStyle(
                 color: Color(0xFF222222),
                 fontSize: 16,

--- a/lib/presentation/pages/setting/setting_page.dart
+++ b/lib/presentation/pages/setting/setting_page.dart
@@ -27,8 +27,12 @@ class SettingPage extends ConsumerWidget {
 
           // 기본 설정 항목들
           SettingTile(
-            title: '신청 내역',
-            onTap: () => viewModel.navigateToApplyHistory(context),
+            title: '팀 신청내역',
+            onTap: () => viewModel.navigateToTeamApplyHistory(context),
+          ),
+          SettingTile(
+            title: '용병 신청내역',
+            onTap: () => viewModel.navigateToMercenaryApplyHistory(context),
           ),
           SettingTile(
             title: '알림 설정',

--- a/lib/presentation/pages/setting/viewmodel/setting_view_model.dart
+++ b/lib/presentation/pages/setting/viewmodel/setting_view_model.dart
@@ -23,8 +23,12 @@ class SettingViewModel {
     Navigator.pushNamed(context, '/alarm_setting');
   }
 
-  void navigateToApplyHistory(BuildContext context) {
-    Navigator.pushNamed(context, '/apply_history');
+  void navigateToTeamApplyHistory(BuildContext context) {
+    Navigator.pushNamed(context, '/team_apply_history');
+  }
+
+  void navigateToMercenaryApplyHistory(BuildContext context) {
+    Navigator.pushNamed(context, '/mercenary_apply_history');
   }
 
   Future<void> showPolicyLinks(BuildContext context) async {

--- a/lib/presentation/pages/setting/widget/profile_section.dart
+++ b/lib/presentation/pages/setting/widget/profile_section.dart
@@ -72,7 +72,6 @@ class _ProfileSectionState extends State<ProfileSection> {
     // 카카오 API에서 가져온 사용자 정보
     final profile = kakaoUser?.kakaoAccount?.profile;
     final nickname = profile?.nickname ?? '사용자';
-    final email = kakaoUser?.kakaoAccount?.email ?? '이메일 정보 없음';
     final profileImageUrl = profile?.profileImageUrl;
     final thumbnailImageUrl = profile?.thumbnailImageUrl;
 
@@ -118,14 +117,6 @@ class _ProfileSectionState extends State<ProfileSection> {
                     overflow: TextOverflow.ellipsis,
                   ),
                   const SizedBox(height: 4),
-                  Text(
-                    email,
-                    style: const TextStyle(
-                      fontSize: 14,
-                      color: Color(0xFF757B80),
-                    ),
-                    overflow: TextOverflow.ellipsis,
-                  ),
                 ],
               ),
             ),

--- a/lib/presentation/pages/team_apply_history/team_apply_history_item.dart
+++ b/lib/presentation/pages/team_apply_history/team_apply_history_item.dart
@@ -1,0 +1,200 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:mercenaryhub/domain/entity/team_apply_history.dart';
+
+class TeamApplyHistoryItem extends StatelessWidget {
+  final TeamApplyHistory history;
+  final Function(String status) onStatusUpdate;
+
+  const TeamApplyHistoryItem({
+    super.key,
+    required this.history,
+    required this.onStatusUpdate,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: Colors.grey[300]!),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withOpacity(0.05),
+            blurRadius: 4,
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              CircleAvatar(
+                radius: 24,
+                backgroundColor: Colors.grey[300],
+                backgroundImage: history.mercenaryProfileImage.isNotEmpty
+                    ? NetworkImage(history.mercenaryProfileImage)
+                    : null,
+                child: history.mercenaryProfileImage.isEmpty
+                    ? const Icon(Icons.person, color: Colors.grey)
+                    : null,
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      history.mercenaryName,
+                      style: const TextStyle(
+                        fontSize: 16,
+                        fontWeight: FontWeight.bold,
+                        color: Color(0xFF222222),
+                      ),
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      '신청일: ${DateFormat('yyyy.MM.dd').format(history.appliedAt)}',
+                      style: TextStyle(
+                        fontSize: 14,
+                        color: Colors.grey[600],
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              _buildStatusChip(history.status),
+            ],
+          ),
+          const SizedBox(height: 16),
+          Container(
+            padding: const EdgeInsets.all(12),
+            decoration: BoxDecoration(
+              color: Colors.grey[50],
+              borderRadius: BorderRadius.circular(8),
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                _buildInfoRow(Icons.location_on, history.location),
+                const SizedBox(height: 8),
+                _buildInfoRow(
+                  Icons.calendar_today,
+                  DateFormat('yyyy년 MM월 dd일').format(history.gameDate),
+                ),
+                const SizedBox(height: 8),
+                _buildInfoRow(Icons.access_time, history.gameTime),
+                const SizedBox(height: 8),
+                _buildInfoRow(Icons.military_tech, history.level),
+              ],
+            ),
+          ),
+          if (history.status == 'pending') ...[
+            const SizedBox(height: 16),
+            Row(
+              children: [
+                Expanded(
+                  child: OutlinedButton(
+                    onPressed: () => onStatusUpdate('rejected'),
+                    style: OutlinedButton.styleFrom(
+                      foregroundColor: Colors.red,
+                      side: const BorderSide(color: Colors.red),
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                    ),
+                    child: const Text('거절'),
+                  ),
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: ElevatedButton(
+                    onPressed: () => onStatusUpdate('accepted'),
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: const Color(0xFF2BBB7D),
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                    ),
+                    child: const Text(
+                      '수락',
+                      style: TextStyle(color: Colors.white),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  Widget _buildStatusChip(String status) {
+    Color backgroundColor;
+    Color textColor;
+    String text;
+
+    switch (status) {
+      case 'pending':
+        backgroundColor = Colors.orange[100]!;
+        textColor = Colors.orange[800]!;
+        text = '대기중';
+        break;
+      case 'accepted':
+        backgroundColor = Colors.green[100]!;
+        textColor = Colors.green[800]!;
+        text = '수락됨';
+        break;
+      case 'rejected':
+        backgroundColor = Colors.red[100]!;
+        textColor = Colors.red[800]!;
+        text = '거절됨';
+        break;
+      default:
+        backgroundColor = Colors.grey[100]!;
+        textColor = Colors.grey[800]!;
+        text = '알 수 없음';
+    }
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+      decoration: BoxDecoration(
+        color: backgroundColor,
+        borderRadius: BorderRadius.circular(16),
+      ),
+      child: Text(
+        text,
+        style: TextStyle(
+          fontSize: 12,
+          fontWeight: FontWeight.bold,
+          color: textColor,
+        ),
+      ),
+    );
+  }
+
+  Widget _buildInfoRow(IconData icon, String text) {
+    return Row(
+      children: [
+        Icon(
+          icon,
+          size: 16,
+          color: Colors.grey[600],
+        ),
+        const SizedBox(width: 8),
+        Text(
+          text,
+          style: TextStyle(
+            fontSize: 14,
+            color: Colors.grey[800],
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/presentation/pages/team_apply_history/team_apply_history_page.dart
+++ b/lib/presentation/pages/team_apply_history/team_apply_history_page.dart
@@ -1,0 +1,114 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:mercenaryhub/presentation/pages/team_apply_history/team_apply_history_item.dart';
+import 'package:mercenaryhub/presentation/pages/team_apply_history/team_apply_history_view_model.dart';
+
+class TeamApplyHistoryPage extends ConsumerWidget {
+  const TeamApplyHistoryPage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final state = ref.watch(teamApplyHistoryViewModelProvider);
+
+    return Scaffold(
+      backgroundColor: const Color(0xFFFFFFFF),
+      appBar: AppBar(
+        backgroundColor: const Color(0xFFFFFFFF),
+        foregroundColor: const Color(0xFF222222),
+        elevation: 0,
+        title: const Text('팀 신청내역'),
+        shape: Border(
+          bottom: BorderSide(
+            color: Colors.grey[300]!,
+          ),
+        ),
+      ),
+      body: state.when(
+        data: (histories) {
+          if (histories.isEmpty) {
+            return Center(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Icon(
+                    Icons.inbox_outlined,
+                    size: 64,
+                    color: Colors.grey[400],
+                  ),
+                  const SizedBox(height: 16),
+                  Text(
+                    '신청내역이 없습니다',
+                    style: TextStyle(
+                      fontSize: 16,
+                      color: Colors.grey[600],
+                    ),
+                  ),
+                ],
+              ),
+            );
+          }
+
+          return RefreshIndicator(
+            onRefresh: () async {
+              ref.invalidate(teamApplyHistoryViewModelProvider);
+            },
+            color: const Color(0xFF2BBB7D),
+            child: ListView.separated(
+              padding: const EdgeInsets.all(16),
+              itemCount: histories.length,
+              separatorBuilder: (context, index) => const SizedBox(height: 12),
+              itemBuilder: (context, index) {
+                return TeamApplyHistoryItem(
+                  history: histories[index],
+                  onStatusUpdate: (status) {
+                    ref
+                        .read(teamApplyHistoryViewModelProvider.notifier)
+                        .updateStatus(histories[index].id, status);
+                  },
+                );
+              },
+            ),
+          );
+        },
+        loading: () => const Center(
+          child: CircularProgressIndicator(
+            color: Color(0xFF2BBB7D),
+          ),
+        ),
+        error: (error, stack) => Center(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              const Icon(
+                Icons.error_outline,
+                size: 64,
+                color: Colors.red,
+              ),
+              const SizedBox(height: 16),
+              const Text(
+                '오류가 발생했습니다',
+                style: TextStyle(
+                  fontSize: 16,
+                  color: Color(0xFF222222),
+                ),
+              ),
+              const SizedBox(height: 8),
+              ElevatedButton(
+                onPressed: () {
+                  ref.invalidate(teamApplyHistoryViewModelProvider);
+                },
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: const Color(0xFF2BBB7D),
+                ),
+                child: const Text(
+                  '다시 시도',
+                  style: TextStyle(color: Colors.white),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/pages/team_apply_history/team_apply_history_view_model.dart
+++ b/lib/presentation/pages/team_apply_history/team_apply_history_view_model.dart
@@ -1,0 +1,89 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:mercenaryhub/domain/entity/team_apply_history.dart';
+import 'package:mercenaryhub/presentation/pages/providers.dart';
+
+class TeamApplyHistoryViewModel extends AsyncNotifier<List<TeamApplyHistory>> {
+  @override
+  Future<List<TeamApplyHistory>> build() async {
+    return await fetchTeamApplyHistories();
+  }
+
+  Future<List<TeamApplyHistory>> fetchTeamApplyHistories() async {
+    await Future.delayed(const Duration(milliseconds: 500)); // 로딩 시뮬레이션
+
+    return [
+      TeamApplyHistory(
+        id: 'dummy1',
+        teamName: 'FC 더미팀',
+        mercenaryUserId: 'user123',
+        mercenaryName: '홍길동',
+        mercenaryProfileImage: 'https://via.placeholder.com/150',
+        feedId: 'feed1',
+        appliedAt: DateTime.now().subtract(const Duration(days: 1)),
+        status: 'pending',
+        location: '서울 마포구',
+        gameDate: DateTime.now().add(const Duration(days: 3)),
+        gameTime: '18:00',
+        level: '중급',
+      ),
+      TeamApplyHistory(
+        id: 'dummy2',
+        teamName: '서울유나이티드',
+        mercenaryUserId: 'user456',
+        mercenaryName: '김철수',
+        mercenaryProfileImage: 'https://via.placeholder.com/150',
+        feedId: 'feed2',
+        appliedAt: DateTime.now().subtract(const Duration(days: 2)),
+        status: 'accepted',
+        location: '서울 강남구',
+        gameDate: DateTime.now().add(const Duration(days: 5)),
+        gameTime: '20:00',
+        level: '상급',
+      ),
+    ];
+  }
+
+  // Future<List<TeamApplyHistory>> fetchTeamApplyHistories() async {
+  //   final fetchUsecase = ref.read(fetchTeamApplyHistoriesUsecaseProvider);
+
+  //   // TODO: 실제 팀 ID를 가져오는 로직 필요
+  //   // 현재는 임시로 사용자 UID를 사용
+  //   final user = FirebaseAuth.instance.currentUser;
+  //   if (user == null) {
+  //     throw Exception('로그인이 필요합니다');
+  //   }
+
+  //   return await fetchUsecase.execute(user.uid);
+  // }
+
+  Future<void> updateStatus(String applyHistoryId, String status) async {
+    final updateUsecase = ref.read(updateTeamApplyStatusUsecaseProvider);
+
+    state = const AsyncValue.loading();
+
+    try {
+      final success = await updateUsecase.execute(
+        applyHistoryId: applyHistoryId,
+        status: status,
+      );
+
+      if (success) {
+        // 상태 업데이트 후 목록 새로고침
+        state = await AsyncValue.guard(() => fetchTeamApplyHistories());
+      } else {
+        state = AsyncValue.error(
+          '상태 업데이트에 실패했습니다',
+          StackTrace.current,
+        );
+      }
+    } catch (e, stack) {
+      state = AsyncValue.error(e, stack);
+    }
+  }
+}
+
+final teamApplyHistoryViewModelProvider =
+    AsyncNotifierProvider<TeamApplyHistoryViewModel, List<TeamApplyHistory>>(
+  () => TeamApplyHistoryViewModel(),
+);


### PR DESCRIPTION
# 🚀 개요
<Setting page 신청내역 페이지 추가(더미데이터 추가), 카카오 이메일 삭제>




# 🔧 변경사항
<Setting page내 신청내역 구분, 더미데이터 생성
용병, 팀 데이터 Class 생성, 신청내역 UI 구현 >




# 🖼️ 실행 화면
<![{65E12E3E-7413-4822-BAE3-9123E378D67C}](https://github.com/user-attachments/assets/3a187f08-6e1b-4224-882f-d4cb7ba8d85f)
![{87651B20-F545-4C81-A839-7214C1B4FA36}](https://github.com/user-attachments/assets/35ea5f6c-089b-4fb0-a1f9-dcd50f69e512)
>

